### PR TITLE
Fixes

### DIFF
--- a/tutorial/parareal_lorenz63.py
+++ b/tutorial/parareal_lorenz63.py
@@ -85,7 +85,7 @@ def parareal(a,b,nG,nF,K,y0,f,G,F):
     # 1,2,3 suffix are the x,y,z dimensions
     xG = np.linspace(a,b,nG+1)
     yG = np.zeros((3,len(xG),K))
-    deltaG = (b-a)/(nG+1)
+    deltaG = (b-a)/nG
     #print(deltaG, nG)
     yG[:,0,:] = np.array([i * np.ones(K) for i in y0])
     xF = np.zeros((nG, int(nF/nG)+1))


### PR DESCRIPTION
This makes a couple of small changes:

1. fix the array length for the fine solution on each time slice - this is not the total number of fine timesteps `nF` but the number of fine timesteps per time slice (i.e. `nF/nG`)
2. correct the coarse timestep `deltaG` calculation
3. set `nG` to be the same as in the Gander paper